### PR TITLE
Updates to SectionAnalysis

### DIFF
--- a/test/section.tcl
+++ b/test/section.tcl
@@ -19,7 +19,7 @@ set H  [expr $E*$Eh/($E-$Eh)]
 
 uniaxialMaterial Hardening 1 $E $Fy $H 0.0
 
-section Fiber 1 {
+section Fiber 1 -GJ 1 {
     # Flanges
     set nX $nfx
     set nY [expr int(ceil($nfy*$tf/$d))]


### PR DESCRIPTION
- OpenSees complains at you if you create a fiber section without a GJ value. Fixed in the test section.
- Updated getDiscretization using JSON output for newer versions of OpenSees.